### PR TITLE
[DONE] authentication bug

### DIFF
--- a/tests/test_threedi_api_client.py
+++ b/tests/test_threedi_api_client.py
@@ -4,9 +4,9 @@ from threedi_api_client import ThreediApiClient
 def test_init_threedi_api_client_from_env_file(tmpdir):
     env_file = tmpdir / 'env_file'
     with open(str(env_file), 'w') as f:
-        f.write("API_HOST=localhost:8000/v3.0")
-        f.write("API_USERNAME=username")
-        f.write("API_PASSWORD=password")
+        f.write("API_HOST=localhost:8000/v3.0\n")
+        f.write("API_USERNAME=username\n")
+        f.write("API_PASSWORD=password\n")
     ThreediApiClient(env_file=str(env_file))
 
 

--- a/threedi_api_client/threedi_api_client.py
+++ b/threedi_api_client/threedi_api_client.py
@@ -43,6 +43,7 @@ def is_token_usable(token: str) -> bool:
 
 
 def refresh_api_key(config: Configuration):
+    """Refreshes the access key if its expired"""
     api_key = config.api_key.get("Authorization")
     if is_token_usable(api_key):
         return

--- a/threedi_api_client/threedi_api_client.py
+++ b/threedi_api_client/threedi_api_client.py
@@ -13,52 +13,49 @@ from threedi_api_client.config import Config, EnvironConfig
 EXPIRE_LEEWAY = -300
 
 
-class APIConfiguration(Configuration):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._access_token = None
-
-    def _is_token_usable(self):
-        if self._access_token is None:
-            return False
-
-        # Check if not expired...
-        try:
-            jwt.decode(
-                self._access_token,
-                options={"verify_signature": False},
-                leeway=EXPIRE_LEEWAY,
-            )
-        except Exception:
-            return False
-
-        return True
-
-    def _get_api_tokens(self, username, password):
-        configuration = Configuration()
-        configuration.host = self._user_config.get("API_HOST")
-        api_client = ApiClient(configuration)
-        auth = AuthApi(api_client)
-        return auth.auth_token_create(Authenticate(username, password))
-
-    @property
-    def access_token(self):
-        if self._is_token_usable():
-            return self._access_token
-        # Access token is not usable (None/expired)
-        # get a new one
-        tokens = self._get_api_tokens(
-            self._user_config.get("API_USERNAME"),
-            self._user_config.get("API_PASSWORD"),
+def get_api_key(username: str, password: str, api_host: str):
+    api_client = ApiClient(
+        Configuration(
+            username=username,
+            password=password,
+            host=api_host
         )
-        self._access_token = tokens.access
-        return self._access_token
+    )
+    auth = AuthApi(api_client)
+    return auth.auth_token_create(Authenticate(username, password))
 
-    def get_api_key_with_prefix(self, identifier):
-        if identifier == 'Authorization':
-            self.api_key["Authorization"] = self.access_token
-            self.api_key_prefix["Authorization"] = "Bearer"
-        return super().get_api_key_with_prefix(identifier)
+
+def is_token_usable(token: str) -> bool:
+    if token is None:
+        return False
+
+    # Check if not expired...
+    try:
+        jwt.decode(
+            token,
+            options={"verify_signature": False},
+            leeway=EXPIRE_LEEWAY,
+        )
+    except Exception:
+        return False
+
+    return True
+
+
+def refresh_api_key(config: Configuration):
+    api_key = config.api_key.get("Authorization")
+    if is_token_usable(api_key):
+        return
+
+    api_client = ApiClient(Configuration(config.host))
+    auth = AuthApi(api_client)
+    new_api_key = auth.auth_refresh_token_create(
+        {"refresh": config.api_key['refresh']}
+    )
+    config.api_key = {
+        'Authorization': new_api_key.access,
+        'refresh': new_api_key.refresh
+    }
 
 
 class ThreediApiClient:
@@ -70,7 +67,18 @@ class ThreediApiClient:
         else:
             user_config = EnvironConfig()
 
-        configuration = APIConfiguration()
-        configuration.host = user_config.get("API_HOST")
-        configuration._user_config = user_config
-        return ApiClient(configuration)
+        api_key = get_api_key(
+            username=user_config.get("API_USERNAME"),
+            password=user_config.get("API_PASSWORD"),
+            api_host=user_config.get("API_HOST")
+        )
+        configuration = Configuration(
+            host=user_config.get("API_HOST"),
+            username=user_config.get("API_USERNAME"),
+            password=user_config.get("API_PASSWORD"),
+            api_key={"Authorization": api_key.access, "refresh": api_key.refresh},
+            api_key_prefix={"Authorization": "Bearer"}
+        )
+        configuration.refresh_api_key_hook = refresh_api_key
+        api_client = ApiClient(configuration)
+        return api_client


### PR DESCRIPTION
closes https://github.com/nens/threedi-api/issues/332

This new ThreediApiClient makes use of the `refresh_api_key_hook` in the configuration. 
Furthermore, it now uses the `refresh_token` (if its valid) when the `access_token` has expired. 

Currently the refresh and access token both expire after 1 day in thus the refresh token won't be used. We might want to change that because using the refresh-token no database queries are required.

- [ ] create the new openapi_client with openapi-generator-cli:v4.3.0 (skipped for now so it's easy to see the changes in the `threedi_api_client`)