### PR TITLE
[Done] File upload

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -130,19 +130,38 @@ def fileobj():
     return stream
 
 
-def test_upload_fileobj(pool, fileobj, upload_response):
+@pytest.mark.parametrize(
+    "chunk_size,expected_body",
+    [
+        (64, [b"X" * 39]),
+        (39, [b"X" * 39]),
+        (38, [b"X" * 38, b"X"]),
+        (16, [b"X" * 16, b"X" * 16, b"X" * 7]),
+    ],
+)
+def test_upload_fileobj(pool, fileobj, upload_response, chunk_size, expected_body):
     pool.request.return_value = upload_response
-    upload_fileobj("some-url", fileobj, pool=pool)
+    upload_fileobj("some-url", fileobj, chunk_size=chunk_size, pool=pool)
 
     # base64.b64encode(hashlib.md5(b"X" * 39).digest()).decode()
     expected_md5 = "Q2zMNJgyazDIkoSqvpOqVg=="
-    pool.request.assert_called_with(
-        "PUT",
-        "some-url",
-        body=b"X" * 39,
-        headers={"Content-Length": "39", "Content-MD5": expected_md5},
-        timeout=5.0,
-    )
+
+    args, kwargs = pool.request.call_args
+    assert args == ("PUT", "some-url")
+    assert list(kwargs["body"]) == expected_body
+    assert kwargs["headers"] == {"Content-Length": "39", "Content-MD5": expected_md5}
+    assert kwargs["timeout"] == 5.0
+
+
+def test_upload_fileobj_with_md5(pool, fileobj, upload_response):
+    pool.request.return_value = upload_response
+    upload_fileobj("some-url", fileobj, pool=pool, md5=b"abcd")
+
+    # base64.b64encode(b"abcd")).decode()
+    expected_md5 = "YWJjZA=="
+
+    args, kwargs = pool.request.call_args
+    assert kwargs["headers"] == {"Content-Length": "39", "Content-MD5": expected_md5}
 
 
 def test_upload_fileobj_empty_file():
@@ -170,7 +189,9 @@ def test_upload_file(upload_fileobj, tmp_path):
     with path.open("wb") as f:
         f.write(b"X")
 
-    upload_file("http://domain/a.b", path, timeout=3.0, pool="foo")
+    upload_file(
+        "http://domain/a.b", path, chunk_size=1234, timeout=3.0, pool="foo", md5=b"abcd"
+    )
 
     args, kwargs = upload_fileobj.call_args
     assert args[0] == "http://domain/a.b"
@@ -178,4 +199,6 @@ def test_upload_file(upload_fileobj, tmp_path):
     assert args[1].mode == "rb"
     assert args[1].name == str(path)
     assert kwargs["timeout"] == 3.0
+    assert kwargs["chunk_size"] == 1234
     assert kwargs["pool"] == "foo"
+    assert kwargs["md5"] == b"abcd"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -5,8 +5,10 @@ import pytest
 from urllib3.response import HTTPResponse
 
 from openapi_client.exceptions import ApiException
-from threedi_api_client.files import (download_file, download_fileobj,
-                                      upload_file, upload_fileobj)
+from threedi_api_client.files import download_file
+from threedi_api_client.files import download_fileobj
+from threedi_api_client.files import upload_file
+from threedi_api_client.files import upload_fileobj
 
 
 @pytest.fixture

--- a/threedi_api_client/files.py
+++ b/threedi_api_client/files.py
@@ -226,9 +226,6 @@ def upload_fileobj(
             invalid HTTP headers, payload too large (HTTP 413), too many
             requests (HTTP 429), service unavailable (HTTP 503)
     """
-    if pool is None:
-        pool = get_pool()
-
     # There are two ways to upload in S3 (Minio):
     # - PutObject: put the whole object in one time
     # - multipart upload: requires presigned urls for every part
@@ -240,10 +237,13 @@ def upload_fileobj(
         )
     length = len(body)
     if length == 0:
-        raise IOError("The provided file is empty.")
+        raise IOError("The file object is empty.")
 
     # Make a hash so that the file server can check integerity.
     md5 = base64.b64encode(hashlib.md5(body).digest())
+
+    if pool is None:
+        pool = get_pool()
 
     headers = {"Content-Length": str(length), "Content-MD5": md5.decode()}
     response = pool.request("PUT", url, body=body, headers=headers, timeout=timeout)

--- a/threedi_api_client/files.py
+++ b/threedi_api_client/files.py
@@ -47,13 +47,13 @@ def download_file(
         target: The location to copy to. If this is an existing file, it is
             overwritten. If it is a directory, a filename is generated from
             the filename in the url.
-        chunk_size: The numer of bytes per request. Default: 16MB.
+        chunk_size: The number of bytes per request. Default: 16MB.
         timeout: The total timeout in seconds.
         pool: If not supplied, a default connection pool will be
             created with a retry policy of 3 retries after 1, 2, 4 seconds.
 
     Returns:
-        Tuple of file path, total amount of uploaded bytes.
+        Tuple of file path, total number of uploaded bytes.
 
     Raises:
         openapi_client.exceptions.ApiException: raised on unexpected server
@@ -95,13 +95,13 @@ def download_fileobj(
     Args:
         url: The url to retrieve.
         fileobj: The (binary) file object to write into.
-        chunk_size: The numer of bytes per request. Default: 16MB.
+        chunk_size: The number of bytes per request. Default: 16MB.
         timeout: The total timeout in seconds.
         pool: If not supplied, a default connection pool will be
             created with a retry policy of 3 retries after 1, 2, 4 seconds.
 
     Returns:
-        The total amount of downloaded bytes.
+        The total number of downloaded bytes.
 
     Raises:
         openapi_client.exceptions.ApiException: raised on unexpected server
@@ -165,9 +165,8 @@ def upload_file(
 ) -> int:
     """Upload a file at specified file path to a url.
 
-    The upload is accompanied by an MD5 hash so that the file server can check
-    the integrity of the file. This function is not inteded for files larger than
-    1 GB.
+    The upload is accompanied by an MD5 hash so that the file server checks
+    the integrity of the file.
 
     Args:
         url: The url to upload to.
@@ -181,7 +180,7 @@ def upload_file(
             have access to it. Otherwise this function will compute it for you.
 
     Returns:
-        The total amount of uploaded bytes.
+        The total number of uploaded bytes.
 
     Raises:
         IOError: Raised if the provided file is incompatible or empty.

--- a/threedi_api_client/files.py
+++ b/threedi_api_client/files.py
@@ -124,8 +124,6 @@ def download_fileobj(
         stop = start + chunk_size - 1
         headers = {"Range": "bytes={}-{}".format(start, stop)}
 
-        # Send the request and get the data with the openapi-generator
-        # ApiClient instance. It will raise on non-2XX responses.
         response = pool.request(
             "GET",
             url,


### PR DESCRIPTION
There are two ways to upload in S3 (Minio):
- PutObject: put the whole object in one time
- multipart upload: requires presigned urls for every part
We can only do the first option as we have no other presigned urls.

When doing an upload as a single request, you still have the option to stream the upload by supplying the file stream as the `body`. Urllib3 will in that case forward the stream to http.HTTPConnection.request, which will stream using a rather small blocksize of 8192. This blocksize is hardcoded.

If we would do that, we would have to pass through the file 2 times, once for computing the MD5 hash, once for the upload. So I think that reading the thing in memory is the way to go here.